### PR TITLE
validate stored `blockId`

### DIFF
--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -9,6 +9,13 @@ function Wrapper() {
     "blockId",
     blocksConfig[0].entry
   );
+
+  // validate stored blockId
+  useEffect(() => {
+    if (!blocksConfig.find((v) => v.entry === blockId))
+      setBlockId(blocksConfig[0].entry);
+  });
+
   const [fileUrl, setFileUrl] = useLocalStorage(
     "fileUrl",
     "https://github.com/githubocto/flat/blob/main/src/git.ts"


### PR DESCRIPTION
if you rename the example block after viewing it in the dev sandbox, you can wind up in a state where the `blockId` in local storage doesn't match any block in `blocks.config.json`, and your block mysteriously doesn't display.