### PR TITLE
add KV store API to Blocks

### DIFF
--- a/src/components/callback-notifications.tsx
+++ b/src/components/callback-notifications.tsx
@@ -44,24 +44,19 @@ export const CallbackNotifications = ({}) => {
           ),
           details: JSON.stringify(event.data.config, null, 2),
         },
-        "kv-get--request": {
-          title: "KV get",
-          info: <>Requested KV get:</>,
+        "store-get--request": {
+          title: "Store get",
+          info: <>Requested store get:</>,
           details: event.data.key,
         },
-        "kv-set": {
-          title: "KV set",
-          info: <>Requested KV set:</>,
+        "store-set": {
+          title: "Store set",
+          info: <>Requested store set:</>,
           details: JSON.stringify(
             { key: event.data.key, value: event.data.value },
             null,
             2
           ),
-        },
-        "kv-delete": {
-          title: "KV delete",
-          info: <>Requested KV delete:</>,
-          details: event.data.key,
         },
       }[eventType];
       if (!type) return;

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -48,7 +48,7 @@ export const LocalBlock = (props: LocalBlockProps) => {
     if (!(blockKey in kvStore)) {
       kvStore[blockKey] = {};
     }
-  });
+  }, [blockKey]);
 
   const getContents = async () => {
     const importPrefix = "../../../../../";
@@ -112,11 +112,11 @@ export const LocalBlock = (props: LocalBlockProps) => {
     return data;
   };
 
-  const onKVGet = async (key: string) => {
-    styledLog(`Triggered KV get: ${key}`);
+  const onStoreGet = async (key: string) => {
+    styledLog(`Triggered store get: ${key}`);
     window.postMessage(
       {
-        type: "kv-get--request",
+        type: "store-get--request",
         key,
       },
       "*"
@@ -124,7 +124,7 @@ export const LocalBlock = (props: LocalBlockProps) => {
     const value = kvStore[blockKey][key];
     window.postMessage(
       {
-        type: "kv-get--response",
+        type: "store-get--response",
         value,
       },
       "*"
@@ -132,29 +132,18 @@ export const LocalBlock = (props: LocalBlockProps) => {
     return value;
   };
 
-  const onKVSet = async (key: string, value: any) => {
-    styledLog(`Triggered KV set: ${key} = ${JSON.stringify(value)}`);
+  const onStoreSet = async (key: string, value: any) => {
+    styledLog(`Triggered store set: ${key} = ${JSON.stringify(value)}`);
     window.postMessage(
       {
-        type: "kv-set",
+        type: "store-set",
         key,
         value,
       },
       "*"
     );
-    kvStore[blockKey][key] = JSON.parse(JSON.stringify(value));
-  };
-
-  const onKVDelete = async (key: string) => {
-    styledLog(`Triggered KV delete: ${key}`);
-    window.postMessage(
-      {
-        type: "kv-delete",
-        key,
-      },
-      "*"
-    );
-    delete kvStore[blockKey][key];
+    if (value === undefined) delete kvStore[blockKey][key];
+    else kvStore[blockKey][key] = JSON.parse(JSON.stringify(value));
   };
 
   if (!Block) return null;
@@ -172,9 +161,8 @@ export const LocalBlock = (props: LocalBlockProps) => {
           onNavigateToPath={onNavigateToPath}
           onUpdateContent={setContent}
           onRequestGitHubData={onRequestGitHubData}
-          onKVGet={onKVGet}
-          onKVSet={onKVSet}
-          onKVDelete={onKVDelete}
+          onStoreGet={onStoreGet}
+          onStoreSet={onStoreSet}
         />
       </BaseStyles>
     </ThemeProvider>

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -53,9 +53,8 @@ export type CommonBlockProps = {
     params?: Record<string, any>
   ) => Promise<any>;
 
-  onKVGet: (key: string) => Promise<any>;
-  onKVSet: (key: string, value: any) => Promise<void>;
-  onKVDelete: (key: string) => Promise<void>;
+  onStoreGet: (key: string) => Promise<any>;
+  onStoreSet: (key: string, value: any) => Promise<void>;
 
   // private API for use by githubnext/blocks-examples blocks only
   BlockComponent: any;


### PR DESCRIPTION
This will be implemented on Cosmos DB in actual Blocks app; here it just stores locally in memory.

(I hooked up the message passing stuff for callback notifications, but it turns out it doesn't display for local mode. I've left the changes in, not sure if we want it to display in local mode.)