### PR TITLE
Getting raw data from `onRequestGitHubData`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,8 +19,8 @@ export const callbackFunctions: Pick<
   onUpdateMetadata: (metadata) => makeRequest("onUpdateMetadata", { metadata }),
   onNavigateToPath: (path) => makeRequest("onNavigateToPath", { path }),
   onUpdateContent: (content) => makeRequest("onUpdateContent", { content }),
-  onRequestGitHubData: (path, params) =>
-    makeRequest("onRequestGitHubData", { path, params }),
+  onRequestGitHubData: (path, params, rawData) =>
+    makeRequest("onRequestGitHubData", { path, params, rawData }),
   onStoreGet: (key) => makeRequest("onStoreGet", { key }),
   onStoreSet: (key, value) =>
     makeRequest("onStoreSet", { key, value }) as Promise<void>,

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -50,7 +50,8 @@ export type CommonBlockProps = {
   onUpdateContent: (_: string) => void;
   onRequestGitHubData: (
     path: string,
-    params?: Record<string, any>
+    params?: Record<string, any>,
+    rawData?: boolean
   ) => Promise<any>;
 
   onRequestBlocksRepos: (params?: {


### PR DESCRIPTION
Add option to get raw data (`Blob` object) from `onRequestGitHubData`. 