### PR TITLE
feat: type safe onRequestGitHubData

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "dependencies": {
     "@loadable/component": "^5.15.0",
+    "@octokit/endpoint": "^7.0.3",
     "@octokit/openapi-types": "^11.2.0",
+    "@octokit/types": "^8.0.0",
     "@primer/octicons-react": "^17.3.0",
     "@primer/react": "^35.2.1",
     "@vitejs/plugin-react": "^2.0.1",

--- a/src/init.tsx
+++ b/src/init.tsx
@@ -3,7 +3,7 @@ import App from "./components/PageWrapper";
 import "./index.css";
 
 if (window === window.top) {
-  window.location.href = `https://blocks.githubnext.com/?devServer=${encodeURIComponent(
+  window.location.href = `http://localhost:3000/?devServer=${encodeURIComponent(
     window.location.href
   )}`;
 } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,10 @@
-// @ts-nocheck
 import { useEffect, useState } from "react";
 import type {
   BlocksRepo,
   CommonBlockProps,
   FileBlockProps,
   FolderBlockProps,
-} from "@utils";
+} from "../utils/types";
 
 import { Endpoints, OctokitResponse, RequestParameters } from "@octokit/types";
 import { endpoint } from "@octokit/endpoint";
@@ -14,7 +13,7 @@ export async function onRequestGitHubData<T extends keyof Endpoints>(
   route: T,
   parameters?: Endpoints[T]["parameters"] & RequestParameters
 ): Promise<OctokitResponse<Endpoints[T]>["data"]["response"]["data"]> {
-  const params = endpoint<T>(route, parameters);
+  const params = endpoint<T, Endpoints[T]["parameters"]>(route, parameters);
 
   if (params.method !== "GET") {
     throw new Error("Only GET requests are supported.");
@@ -22,10 +21,11 @@ export async function onRequestGitHubData<T extends keyof Endpoints>(
 
   return makeRequest("onRequestGitHubData", {
     path: params.url,
-    headers: params.headers,
-    mediaType: params.mediaType,
+    ...params,
   });
 }
+
+export type OnRequestGitHubData = typeof onRequestGitHubData;
 
 export const callbackFunctions: Pick<
   CommonBlockProps,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { useEffect, useState } from "react";
 import type {
   BlocksRepo,
@@ -5,6 +6,21 @@ import type {
   FileBlockProps,
   FolderBlockProps,
 } from "@utils";
+
+import { Endpoints, OctokitResponse } from "@octokit/types";
+import { endpoint } from "@octokit/endpoint";
+
+export async function onRequestGitHubData<T extends keyof Endpoints>(
+  route: T,
+  parameters?: Endpoints[T]["parameters"]
+): Promise<OctokitResponse<Endpoints[T]>["data"]["response"]["data"]> {
+  const params = endpoint<T>(route, parameters);
+  if (params.method !== "GET") {
+    throw new Error("Only GET requests are supported.");
+  }
+
+  return makeRequest("onRequestGitHubData", { path: params.url });
+}
 
 export const callbackFunctions: Pick<
   CommonBlockProps,
@@ -19,8 +35,7 @@ export const callbackFunctions: Pick<
   onUpdateMetadata: (metadata) => makeRequest("onUpdateMetadata", { metadata }),
   onNavigateToPath: (path) => makeRequest("onNavigateToPath", { path }),
   onUpdateContent: (content) => makeRequest("onUpdateContent", { content }),
-  onRequestGitHubData: (path, params, rawData) =>
-    makeRequest("onRequestGitHubData", { path, params, rawData }),
+  onRequestGitHubData,
   onStoreGet: (key) => makeRequest("onStoreGet", { key }),
   onStoreSet: (key, value) =>
     makeRequest("onStoreSet", { key, value }) as Promise<void>,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,19 +7,24 @@ import type {
   FolderBlockProps,
 } from "@utils";
 
-import { Endpoints, OctokitResponse } from "@octokit/types";
+import { Endpoints, OctokitResponse, RequestParameters } from "@octokit/types";
 import { endpoint } from "@octokit/endpoint";
 
 export async function onRequestGitHubData<T extends keyof Endpoints>(
   route: T,
-  parameters?: Endpoints[T]["parameters"]
+  parameters?: Endpoints[T]["parameters"] & RequestParameters
 ): Promise<OctokitResponse<Endpoints[T]>["data"]["response"]["data"]> {
   const params = endpoint<T>(route, parameters);
+
   if (params.method !== "GET") {
     throw new Error("Only GET requests are supported.");
   }
 
-  return makeRequest("onRequestGitHubData", { path: params.url });
+  return makeRequest("onRequestGitHubData", {
+    path: params.url,
+    headers: params.headers,
+    mediaType: params.mediaType,
+  });
 }
 
 export const callbackFunctions: Pick<

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,4 +1,4 @@
-import { onRequestGitHubData } from "../../src/utils";
+import { OnRequestGitHubData } from "../../src/utils";
 
 export interface Block {
   id: string;
@@ -50,7 +50,7 @@ export type CommonBlockProps = {
   onNavigateToPath: (_: string) => void;
   onRequestUpdateContent: (_: string) => void;
   onUpdateContent: (_: string) => void;
-  onRequestGitHubData: typeof onRequestGitHubData;
+  onRequestGitHubData: OnRequestGitHubData;
   onRequestBlocksRepos: (params?: {
     path?: string;
     searchTerm?: string;

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,3 +1,5 @@
+import { onRequestGitHubData } from "../../src/utils";
+
 export interface Block {
   id: string;
   type: string;
@@ -48,12 +50,7 @@ export type CommonBlockProps = {
   onNavigateToPath: (_: string) => void;
   onRequestUpdateContent: (_: string) => void;
   onUpdateContent: (_: string) => void;
-  onRequestGitHubData: (
-    path: string,
-    params?: Record<string, any>,
-    rawData?: boolean
-  ) => Promise<any>;
-
+  onRequestGitHubData: typeof onRequestGitHubData;
   onRequestBlocksRepos: (params?: {
     path?: string;
     searchTerm?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,10 +460,31 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/endpoint@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.3.tgz#0b96035673a9e3bedf8bab8f7335de424a2147ed"
+  integrity sha512-57gRlb28bwTsdNXq+O3JTQ7ERmBTuik9+LelgcLIVfYwf235VHbN9QNo4kXExtp/h8T423cR5iJThKtFYxC7Lw==
+  dependencies:
+    "@octokit/types" "^8.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/openapi-types@^11.2.0":
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
   integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
+
+"@octokit/openapi-types@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-14.0.0.tgz#949c5019028c93f189abbc2fb42f333290f7134a"
+  integrity sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==
+
+"@octokit/types@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-8.0.0.tgz#93f0b865786c4153f0f6924da067fe0bb7426a9f"
+  integrity sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==
+  dependencies:
+    "@octokit/openapi-types" "^14.0.0"
 
 "@primer/behaviors@1.1.1":
   version "1.1.1"
@@ -1860,6 +1881,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
@@ -2608,6 +2634,11 @@ typescript@^4.4.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 unload@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
https://linear.app/github-next/issue/NEXT-607/type-safeish-onrequestgithubdata

Updates the API of `onRequestGitHubData` so that it mirrors that of `octokit.request` where the first argument is a string that represents an API endpoint, and the second argument is both:
- an array of additional properties pertaining the URL you've specified
- additional request options like headers, media type, etc.

Tested locally, and requires and upstream change in `blocks-platform`.

<img width="1124" alt="CleanShot 2022-12-02 at 11 57 31@2x" src="https://user-images.githubusercontent.com/5148596/205286432-64deb8b8-9e67-4bc4-8d54-aabfa525f2c2.png">
