### PR TITLE
feat: add vitest + buildTree function

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsup --dts",
-    "prepublish": "yarn build"
+    "prepublish": "yarn build",
+    "test": "vitest"
   },
   "bin": {
     "blocks": "./bin/blocks.js"
@@ -60,7 +61,8 @@
     "react-dom": "^18.1.0",
     "tsup": "^5.6.0",
     "typescript": "^4.4.4",
-    "use-debounce": "^8.0.2"
+    "use-debounce": "^8.0.2",
+    "vitest": "^0.26.2"
   },
   "browserslist": {
     "production": [

--- a/test/githubnext-blocks-stub.json
+++ b/test/githubnext-blocks-stub.json
@@ -1,0 +1,308 @@
+{
+  "sha": "3f9e537fd37b2aba54e9c96f5f8d47a068d5a4d4",
+  "url": "https://api.github.com/repos/githubnext/blocks/git/trees/3f9e537fd37b2aba54e9c96f5f8d47a068d5a4d4",
+  "tree": [
+    {
+      "path": ".github",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c5c285e55eefbd579ea8e209d879725c77444629",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/c5c285e55eefbd579ea8e209d879725c77444629"
+    },
+    {
+      "path": ".github/blocks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bcf902176eedefbddc96df2cf18260199582da85",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/bcf902176eedefbddc96df2cf18260199582da85"
+    },
+    {
+      "path": ".github/blocks/all.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "16ecf1b266669cdf1d76216ab319c3047f56dc05",
+      "size": 940,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/16ecf1b266669cdf1d76216ab319c3047f56dc05"
+    },
+    {
+      "path": ".github/blocks/file",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "903383c44c60cbc1d18097498f08bd9652285858",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/903383c44c60cbc1d18097498f08bd9652285858"
+    },
+    {
+      "path": ".github/blocks/file/githubnext__blocks-examples__chart-block",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5a19bc924cb26fcbb75cc24b611807199bc631a6",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/5a19bc924cb26fcbb75cc24b611807199bc631a6"
+    },
+    {
+      "path": ".github/blocks/file/githubnext__blocks-examples__chart-block/examples%2Fweather.csv.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "14d708c5f9092017f302914c7198df3f39480e9c",
+      "size": 98,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/14d708c5f9092017f302914c7198df3f39480e9c"
+    },
+    {
+      "path": ".github/blocks/file/githubnext__blocks-examples__chart",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "831e0d5c0a694c937340a805663380405ae724da",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/831e0d5c0a694c937340a805663380405ae724da"
+    },
+    {
+      "path": ".github/blocks/file/githubnext__blocks-examples__chart/examples%2Fweather.csv.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7630239ea0c2bff8e9db83bbec59a122e8d61005",
+      "size": 55,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/7630239ea0c2bff8e9db83bbec59a122e8d61005"
+    },
+    {
+      "path": ".github/blocks/file/githubnext__blocks-examples__react-feedback-block",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "59399e1841b8c4c628fe5c43acbca47b7966e8a4",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/59399e1841b8c4c628fe5c43acbca47b7966e8a4"
+    },
+    {
+      "path": ".github/blocks/file/githubnext__blocks-examples__react-feedback-block/examples%2FMyComponent.jsx.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a1487119d789eee3778a49fb61b7b434cc6a5a31",
+      "size": 861,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/a1487119d789eee3778a49fb61b7b434cc6a5a31"
+    },
+    {
+      "path": "README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f6d1a4b81f49a808b21d7771a59d81f7186dd4d8",
+      "size": 5841,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/f6d1a4b81f49a808b21d7771a59d81f7186dd4d8"
+    },
+    {
+      "path": "docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "20f7bfdef06094f64ce411349f87a37bb15be242",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/20f7bfdef06094f64ce411349f87a37bb15be242"
+    },
+    {
+      "path": "docs/Developing blocks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "aa44099ccfad821581659376a42d0233b2176e02",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/aa44099ccfad821581659376a42d0233b2176e02"
+    },
+    {
+      "path": "docs/Developing blocks/1 Intro.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "97f3ecfb8eb8c074d2f35c00ad35b77bc94973b6",
+      "size": 2219,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/97f3ecfb8eb8c074d2f35c00ad35b77bc94973b6"
+    },
+    {
+      "path": "docs/Developing blocks/2 Building your first block.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b102b6f091009241b7d5e45d1db2b4a8ba1871b3",
+      "size": 6822,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/b102b6f091009241b7d5e45d1db2b4a8ba1871b3"
+    },
+    {
+      "path": "docs/Developing blocks/3 Deploying your block.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4adb8736e45beebe035c3942d09302180cabdad3",
+      "size": 2838,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/4adb8736e45beebe035c3942d09302180cabdad3"
+    },
+    {
+      "path": "docs/Developing blocks/4 API reference and types.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7b7ccf7080eb557561921a29509f971567f20332",
+      "size": 2896,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/7b7ccf7080eb557561921a29509f971567f20332"
+    },
+    {
+      "path": "examples",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0d8899f91273e3d128ac6d62576fc2d386743afd",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/0d8899f91273e3d128ac6d62576fc2d386743afd"
+    },
+    {
+      "path": "examples/MyComponent.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "69af016f6fdab442f10e777b109ecf5741d69308",
+      "size": 1888,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/69af016f6fdab442f10e777b109ecf5741d69308"
+    },
+    {
+      "path": "examples/avocado.glb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "38a4c4ae23cfab3437e2e813877dba1c8b535c6d",
+      "size": 1030684,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/38a4c4ae23cfab3437e2e813877dba1c8b535c6d"
+    },
+    {
+      "path": "examples/drawing.excalidraw",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4b08a6d4bb4307e69d6437ad85a84c2146e47490",
+      "size": 9155,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/4b08a6d4bb4307e69d6437ad85a84c2146e47490"
+    },
+    {
+      "path": "examples/framer motion docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f25c35381254defb132f99eb14301d77f1b25429",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/f25c35381254defb132f99eb14301d77f1b25429"
+    },
+    {
+      "path": "examples/framer motion docs/example1.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b5d45303288f0c8e4ce0b5aa89de3b9a5bb9cb9a",
+      "size": 715,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/b5d45303288f0c8e4ce0b5aa89de3b9a5bb9cb9a"
+    },
+    {
+      "path": "examples/framer motion docs/example2.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "43a14bbca1be3a0ac9802ef35fcf31afcea708cc",
+      "size": 484,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/43a14bbca1be3a0ac9802ef35fcf31afcea708cc"
+    },
+    {
+      "path": "examples/framer motion docs/example3.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4fb2324b2d72497c53b5d5d27d2f5b9ce8c3a908",
+      "size": 529,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/4fb2324b2d72497c53b5d5d27d2f5b9ce8c3a908"
+    },
+    {
+      "path": "examples/framer motion docs/example4.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e1445083ecc6d44c42e5f839fc47af15e61c07a",
+      "size": 599,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/7e1445083ecc6d44c42e5f839fc47af15e61c07a"
+    },
+    {
+      "path": "examples/framer motion docs/example5.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "40d9e859f0f28829d4d515397ac2b32f508f3d2a",
+      "size": 951,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/40d9e859f0f28829d4d515397ac2b32f508f3d2a"
+    },
+    {
+      "path": "examples/framer motion docs/index.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9592eabde457e22327f226fefffe5239d0a039da",
+      "size": 2486,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/9592eabde457e22327f226fefffe5239d0a039da"
+    },
+    {
+      "path": "examples/lodash docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "56c320adc1d21510aa94445a65417944938195b4",
+      "url": "https://api.github.com/repos/githubnext/blocks/git/trees/56c320adc1d21510aa94445a65417944938195b4"
+    },
+    {
+      "path": "examples/lodash docs/example1.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "859b003b7a1f265951fab0144ae84e0869757461",
+      "size": 90,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/859b003b7a1f265951fab0144ae84e0869757461"
+    },
+    {
+      "path": "examples/lodash docs/example2.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "828184704f1e5b012716dce57c45ad87a91d09f0",
+      "size": 96,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/828184704f1e5b012716dce57c45ad87a91d09f0"
+    },
+    {
+      "path": "examples/lodash docs/example3.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a4ffa13e8b46b79e4548a05aa2751e26ef479cec",
+      "size": 104,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/a4ffa13e8b46b79e4548a05aa2751e26ef479cec"
+    },
+    {
+      "path": "examples/lodash docs/index.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "76309b7b4732b677d1922e435f9113c0df52c15e",
+      "size": 958,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/76309b7b4732b677d1922e435f9113c0df52c15e"
+    },
+    {
+      "path": "examples/machinelearning.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "90c5917f28bc2b20f89eda73aba0c9f42704a48e",
+      "size": 203,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/90c5917f28bc2b20f89eda73aba0c9f42704a48e"
+    },
+    {
+      "path": "examples/p5-sketch.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b999d6a8477de769dfa0295cd4da24b84ae0394f",
+      "size": 354,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/b999d6a8477de769dfa0295cd4da24b84ae0394f"
+    },
+    {
+      "path": "examples/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0cfddc5a23e924e52ab4039378a32e54afe0132f",
+      "size": 7815,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/0cfddc5a23e924e52ab4039378a32e54afe0132f"
+    },
+    {
+      "path": "examples/pets.mermaid",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ecf6f95dd87547b2434481d44ee6a4393589f30d",
+      "size": 83,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/ecf6f95dd87547b2434481d44ee6a4393589f30d"
+    },
+    {
+      "path": "examples/styleguide.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4744514ffe53eb1628c6a5584c8c855af6e30c87",
+      "size": 2433,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/4744514ffe53eb1628c6a5584c8c855af6e30c87"
+    },
+    {
+      "path": "examples/weather.csv",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c2584293f508f7bedb246e3411a46ebeaba9b674",
+      "size": 114079,
+      "url": "https://api.github.com/repos/githubnext/blocks/git/blobs/c2584293f508f7bedb246e3411a46ebeaba9b674"
+    }
+  ],
+  "truncated": false
+}

--- a/test/tree.test.ts
+++ b/test/tree.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import stubTree from "./githubnext-blocks-stub.json";
+import { buildTree } from "../utils/lib/tree";
+
+describe("buildTree", () => {
+  it("converts the flattened tree into a nested data structure", async () => {
+    const tree = buildTree(stubTree.tree);
+
+    let rootFiles = tree.getDirectoryFiles("");
+    expect(rootFiles.length).toBe(1);
+    expect(rootFiles[0].path).toBe("README.md");
+
+    let baseDotGithubFiles = tree.getDirectoryFiles(".github");
+    expect(baseDotGithubFiles.length).toBe(0);
+
+    let nestedDotGithubFiles = tree.getDirectoryFiles(".github/blocks");
+    expect(nestedDotGithubFiles.length).toBe(1);
+    expect(nestedDotGithubFiles[0].path).toBe("all.json");
+    expect(nestedDotGithubFiles[0].meta.type).toBe("blob");
+
+    let recursiveDotGithubFiles = tree.getDirectoryFiles(".github", {
+      recursive: true,
+    });
+
+    expect(recursiveDotGithubFiles.length).toBe(4);
+    expect(recursiveDotGithubFiles[0].meta.path).toBe(
+      ".github/blocks/all.json"
+    );
+    expect(recursiveDotGithubFiles[1].meta.path).toBe(
+      ".github/blocks/file/githubnext__blocks-examples__chart-block/examples%2Fweather.csv.json"
+    );
+    expect(recursiveDotGithubFiles[2].meta.path).toBe(
+      ".github/blocks/file/githubnext__blocks-examples__chart/examples%2Fweather.csv.json"
+    );
+    expect(recursiveDotGithubFiles[3].meta.path).toBe(
+      ".github/blocks/file/githubnext__blocks-examples__react-feedback-block/examples%2FMyComponent.jsx.json"
+    );
+
+    let examplesDir = tree.getDirectoryFiles("examples");
+    expect(examplesDir.length).toBe(9);
+
+    let framerExamples = tree.getDirectoryFiles("examples/framer motion docs");
+    expect(framerExamples.length).toBe(6);
+    expect(framerExamples[0].meta.path).toBe(
+      "examples/framer motion docs/example1.js"
+    );
+  });
+});

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./lib";
+export * from "./lib/tree";
 export * from "./components/block-picker";

--- a/utils/lib/tree.ts
+++ b/utils/lib/tree.ts
@@ -1,0 +1,96 @@
+import { Endpoints } from "@octokit/types";
+
+type RecursiveGitTree =
+  Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["response"]["data"]["tree"];
+
+type RecursiveGitTreeItem = RecursiveGitTree[number];
+
+type ItemType = "blob" | "tree";
+
+class TreeNode {
+  path: string;
+  type: ItemType;
+  meta: RecursiveGitTreeItem;
+  children: TreeNode[];
+
+  constructor(
+    path: string,
+    meta: RecursiveGitTreeItem,
+    type: ItemType,
+    children: TreeNode[] = []
+  ) {
+    this.path = path;
+    this.meta = meta;
+    this.type = type;
+    this.children = children;
+  }
+
+  getDirectoryFiles(
+    path: string,
+    opts?: {
+      recursive?: boolean;
+    }
+  ): TreeNode[] {
+    let options = opts || {
+      recursive: false,
+    };
+    const parts = path.split("/");
+    let currentNode = this as TreeNode;
+    for (const part of parts) {
+      if (!part) continue;
+      let found = false;
+      for (const child of currentNode.children) {
+        if (child.path === part) {
+          currentNode = child;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return [];
+      }
+    }
+    if (options.recursive) {
+      return currentNode.children.flatMap((node) => {
+        if (node.type === "blob") {
+          return [node];
+        } else {
+          return node.getDirectoryFiles("", { recursive: true });
+        }
+      });
+    } else {
+      return currentNode.children.filter((node) => node.type === "blob");
+    }
+  }
+}
+
+export function buildTree(items: RecursiveGitTree) {
+  const root = new TreeNode("/", { path: "/" }, "tree");
+  const nodes = [root];
+
+  for (const item of items) {
+    // It's annoying that Octokit types "path" as optional, but it's never undefined in reality AFAICT.
+    if (!item.path) throw new Error("Item has no path");
+    const parts = item.path.split("/");
+    let currentNode = root;
+    for (const part of parts) {
+      if (!part) continue;
+      let found = false;
+      for (const child of currentNode.children) {
+        if (child.path === part) {
+          currentNode = child;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        const newNode = new TreeNode(part, item, "tree");
+        currentNode.children.push(newNode);
+        currentNode = newNode;
+        nodes.push(newNode);
+      }
+    }
+    currentNode.type = item.type as ItemType;
+  }
+  return root;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,120 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@esbuild/android-arm64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.16.10.tgz#d784d8f13dbef50492ea55456fb50651e4036fbf"
+  integrity sha512-47Y+NwVKTldTlDhSgJHZ/RpvBQMUDG7eKihqaF/u6g7s0ZPz4J1vy8A3rwnnUOF2CuDn7w7Gj/QcMoWz3U3SJw==
+
+"@esbuild/android-arm@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.16.10.tgz#becf6b5647c091b039121db8c17300a7dfd1ab4a"
+  integrity sha512-RmJjQTRrO6VwUWDrzTBLmV4OJZTarYsiepLGlF2rYTVB701hSorPywPGvP6d8HCuuRibyXa5JX4s3jN2kHEtjQ==
+
+"@esbuild/android-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.16.10.tgz#648cacbb13a5047380a038e5d6d895015e31b525"
+  integrity sha512-C4PfnrBMcuAcOurQzpF1tTtZz94IXO5JmICJJ3NFJRHbXXsQUg9RFG45KvydKqtFfBaFLCHpduUkUfXwIvGnRg==
+
+"@esbuild/darwin-arm64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.16.10.tgz#3ca7fd9a456d11752df77df6c030f2d08f27bda9"
+  integrity sha512-bH/bpFwldyOKdi9HSLCLhhKeVgRYr9KblchwXgY2NeUHBB/BzTUHtUSBgGBmpydB1/4E37m+ggXXfSrnD7/E7g==
+
+"@esbuild/darwin-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.16.10.tgz#7eb71b8da4106627f01553def517d3c5e5942592"
+  integrity sha512-OXt7ijoLuy+AjDSKQWu+KdDFMBbdeaL6wtgMKtDUXKWHiAMKHan5+R1QAG6HD4+K0nnOvEJXKHeA9QhXNAjOTQ==
+
+"@esbuild/freebsd-arm64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.10.tgz#c69c78ee1d17d35ad2cf76a1bb67788000a84b43"
+  integrity sha512-shSQX/3GHuspE3Uxtq5kcFG/zqC+VuMnJkqV7LczO41cIe6CQaXHD3QdMLA4ziRq/m0vZo7JdterlgbmgNIAlQ==
+
+"@esbuild/freebsd-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.16.10.tgz#a9804ab1b9366f915812af24ad5cfc1c0db01441"
+  integrity sha512-5YVc1zdeaJGASijZmTzSO4h6uKzsQGG3pkjI6fuXvolhm3hVRhZwnHJkforaZLmzvNv5Tb7a3QL2FAVmrgySIA==
+
+"@esbuild/linux-arm64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.16.10.tgz#d9a9ddfcb28ed8cced688bc112ef66283d6fa77f"
+  integrity sha512-2aqeNVxIaRfPcIaMZIFoblLh588sWyCbmj1HHCCs9WmeNWm+EIN0SmvsmPvTa/TsNZFKnxTcvkX2eszTcCqIrA==
+
+"@esbuild/linux-arm@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.16.10.tgz#f32cdac1d3319c83ae7f9f31238dd1284ee6bba2"
+  integrity sha512-c360287ZWI2miBnvIj23bPyVctgzeMT2kQKR+x94pVqIN44h3GF8VMEs1SFPH1UgyDr3yBbx3vowDS1SVhyVhA==
+
+"@esbuild/linux-ia32@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.16.10.tgz#1e023478e42f3a01cad48f4af50120d4b639af03"
+  integrity sha512-sqMIEWeyrLGU7J5RB5fTkLRIFwsgsQ7ieWXlDLEmC2HblPYGb3AucD7inw2OrKFpRPKsec1l+lssiM3+NV5aOw==
+
 "@esbuild/linux-loong64@0.14.54":
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
   integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
+
+"@esbuild/linux-loong64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.16.10.tgz#f9098865a69d1d6e2f8bda51c7f9d4240f20b771"
+  integrity sha512-O7Pd5hLEtTg37NC73pfhUOGTjx/+aXu5YoSq3ahCxcN7Bcr2F47mv+kG5t840thnsEzrv0oB70+LJu3gUgchvg==
+
+"@esbuild/linux-mips64el@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.16.10.tgz#574725ad2ea81b7783b7ba7d1ab3475f8fdd8d32"
+  integrity sha512-FN8mZOH7531iPHM0kaFhAOqqNHoAb6r/YHW2ZIxNi0a85UBi2DO4Vuyn7t1p4UN8a4LoAnLOT1PqNgHkgBJgbA==
+
+"@esbuild/linux-ppc64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.16.10.tgz#11da658c54514a693813af56bb28951d563a90c3"
+  integrity sha512-Dg9RiqdvHOAWnOKIOTsIx8dFX9EDlY2IbPEY7YFzchrCiTZmMkD7jWA9UdZbNUygPjdmQBVPRCrLydReFlX9yg==
+
+"@esbuild/linux-riscv64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.16.10.tgz#3af4600adbd6c5a4a6f1da05771f4aa6774baab2"
+  integrity sha512-XMqtpjwzbmlar0BJIxmzu/RZ7EWlfVfH68Vadrva0Wj5UKOdKvqskuev2jY2oPV3aoQUyXwnMbMrFmloO2GfAw==
+
+"@esbuild/linux-s390x@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.16.10.tgz#9e3377aaf0191a9d6628e806a279085ec4391f3e"
+  integrity sha512-fu7XtnoeRNFMx8DjK3gPWpFBDM2u5ba+FYwg27SjMJwKvJr4bDyKz5c+FLXLUSSAkMAt/UL+cUbEbra+rYtUgw==
+
+"@esbuild/linux-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.16.10.tgz#7c41d4d697ce674e0083e7baa6231468f4650d85"
+  integrity sha512-61lcjVC/RldNNMUzQQdyCWjCxp9YLEQgIxErxU9XluX7juBdGKb0pvddS0vPNuCvotRbzijZ1pzII+26haWzbA==
+
+"@esbuild/netbsd-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.16.10.tgz#ebac59e3986834af04bbafcee7b0c1f31cd477c6"
+  integrity sha512-JeZXCX3viSA9j4HqSoygjssdqYdfHd6yCFWyfSekLbz4Ef+D2EjvsN02ZQPwYl5a5gg/ehdHgegHhlfOFP0HCA==
+
+"@esbuild/openbsd-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.16.10.tgz#9eaa6cac3b80db45090c0946e62de5b5689c61d1"
+  integrity sha512-3qpxQKuEVIIg8SebpXsp82OBrqjPV/OwNWmG+TnZDr3VGyChNnGMHccC1xkbxCHDQNnnXjxhMQNyHmdFJbmbRA==
+
+"@esbuild/sunos-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.16.10.tgz#31e5e4b814ef43d300e26511e486a4716a390d5f"
+  integrity sha512-z+q0xZ+et/7etz7WoMyXTHZ1rB8PMSNp/FOqURLJLOPb3GWJ2aj4oCqFCjPwEbW1rsT7JPpxeH/DwGAWk/I1Bg==
+
+"@esbuild/win32-arm64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.16.10.tgz#ca58472dc03ca79e6d03f8a31113979ff253d94f"
+  integrity sha512-+YYu5sbQ9npkNT9Dec+tn1F/kjg6SMgr6bfi/6FpXYZvCRfu2YFPZGb+3x8K30s8eRxFpoG4sGhiSUkr1xbHEw==
+
+"@esbuild/win32-ia32@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.16.10.tgz#c572df2c65ab118feed0a5da5a4a193846d74e43"
+  integrity sha512-Aw7Fupk7XNehR1ftHGYwUteyJ2q+em/aE+fVU3YMTBN2V5A7Z4aVCSV+SvCp9HIIHZavPFBpbdP3VfjQpdf6Xg==
+
+"@esbuild/win32-x64@0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.10.tgz#0e9c6a5e69c10d96aff2386b7ee9646138c2a831"
+  integrity sha512-qddWullt3sC1EIpfHvCRBq3H4g3L86DZpD6n8k2XFjFVyp01D++uNbN1hT/JRsHxTbyyemZcpwL5aRlJwc/zFw==
 
 "@github/combobox-nav@^2.1.5":
   version "2.1.5"
@@ -646,6 +756,18 @@
     "@styled-system/core" "^5.1.2"
     "@styled-system/css" "^5.1.5"
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
+  integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -672,6 +794,11 @@
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
+"@types/node@*":
+  version "18.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.17.tgz#5c009e1d9c38f4a2a9d45c0b0c493fe6cdb4bcb5"
+  integrity sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==
 
 "@types/picomatch@^2.3.0":
   version "2.3.0"
@@ -762,6 +889,16 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -798,6 +935,11 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 "babel-plugin-styled-components@>= 1.12.0":
   version "2.0.7"
@@ -888,6 +1030,11 @@ browserslist@^4.20.2:
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 bundle-require@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/bundle-require/-/bundle-require-3.0.4.tgz#2b52ba77d99c0a586b5854cd21d36954e63cc110"
@@ -923,6 +1070,19 @@ caniuse-lite@^1.0.30001332:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz#b5dd7a7941a51a16480bdf6ff82bded1628eec0d"
   integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
 
+chai@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -939,6 +1099,11 @@ chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
@@ -1068,12 +1233,19 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.0, debug@^4.3.1:
+debug@^4.1.0, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -1541,6 +1713,34 @@ esbuild@^0.14.47:
     esbuild-windows-64 "0.14.49"
     esbuild-windows-arm64 "0.14.49"
 
+esbuild@^0.16.3:
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.16.10.tgz#d485c28f1626a3f9c1796c952e4cd0561f0031bb"
+  integrity sha512-z5dIViHoVnw2l+NCJ3zj5behdXjYvXne9gL18OOivCadXDUhyDkeSvEtLcGVAJW2fNmh33TDUpsi704XYlDodw==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.16.10"
+    "@esbuild/android-arm64" "0.16.10"
+    "@esbuild/android-x64" "0.16.10"
+    "@esbuild/darwin-arm64" "0.16.10"
+    "@esbuild/darwin-x64" "0.16.10"
+    "@esbuild/freebsd-arm64" "0.16.10"
+    "@esbuild/freebsd-x64" "0.16.10"
+    "@esbuild/linux-arm" "0.16.10"
+    "@esbuild/linux-arm64" "0.16.10"
+    "@esbuild/linux-ia32" "0.16.10"
+    "@esbuild/linux-loong64" "0.16.10"
+    "@esbuild/linux-mips64el" "0.16.10"
+    "@esbuild/linux-ppc64" "0.16.10"
+    "@esbuild/linux-riscv64" "0.16.10"
+    "@esbuild/linux-s390x" "0.16.10"
+    "@esbuild/linux-x64" "0.16.10"
+    "@esbuild/netbsd-x64" "0.16.10"
+    "@esbuild/openbsd-x64" "0.16.10"
+    "@esbuild/sunos-x64" "0.16.10"
+    "@esbuild/win32-arm64" "0.16.10"
+    "@esbuild/win32-ia32" "0.16.10"
+    "@esbuild/win32-x64" "0.16.10"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -1690,6 +1890,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 get-intrinsic@^1.0.2:
   version "1.1.2"
@@ -1921,6 +2126,11 @@ json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonc-parser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+
 lilconfig@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.5.tgz#19e57fd06ccc3848fd1891655b5a447092225b25"
@@ -1935,6 +2145,11 @@ load-tsconfig@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/load-tsconfig/-/load-tsconfig-0.2.3.tgz#08af3e7744943caab0c75f8af7f1703639c3ef1f"
   integrity sha512-iyT2MXws+dc2Wi6o3grCFtGXpeMvHmJqS27sMPGtV2eUu4PeFnG+33I8BlFK1t1NWMjOpcx9bridn5yxLDX2gQ==
+
+local-pkg@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
+  integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
 
 lodash.uniqueid@^4.0.1:
   version "4.0.1"
@@ -1952,6 +2167,13 @@ loose-envify@^1.1.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+loupe@^2.3.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
 
 magic-string@^0.26.2:
   version "0.26.2"
@@ -2039,6 +2261,16 @@ minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mlly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.0.0.tgz#d38ca6e33ab89b60654f71ef08931d51e83d3569"
+  integrity sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==
+  dependencies:
+    acorn "^8.8.1"
+    pathe "^1.0.0"
+    pkg-types "^1.0.0"
+    ufo "^1.0.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2172,6 +2404,21 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.2.0.tgz#30fd7bbe0a0d91f0e60bae621f5d19e9e225c339"
+  integrity sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==
+
+pathe@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.0.0.tgz#135fc11464fc57c84ef93d5c5ed21247e24571df"
+  integrity sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -2192,6 +2439,15 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
 
+pkg-types@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.0.1.tgz#25234407f9dc63409af45ced9407625ff446a761"
+  integrity sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==
+  dependencies:
+    jsonc-parser "^3.2.0"
+    mlly "^1.0.0"
+    pathe "^1.0.0"
+
 postcss-load-config@^3.0.1:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
@@ -2209,6 +2465,15 @@ postcss@^8.4.14:
   version "8.4.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.20:
+  version "8.4.20"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.20.tgz#64c52f509644cecad8567e949f4081d98349dc56"
+  integrity sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==
   dependencies:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
@@ -2357,6 +2622,13 @@ rollup@^2.75.6:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rollup@^3.7.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.8.1.tgz#d4af8aca7c60d5b8c0281be79ea2fab6b41d458f"
+  integrity sha512-4yh9eMW7byOroYcN8DlF9P/2jCpu6txVIHjEqquQVSx7DI0RgyCCN3tjrcy4ra6yVtV336aLBB3v2AarYAxePQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -2466,6 +2738,19 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
@@ -2485,6 +2770,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-literal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-1.0.0.tgz#0a484ed5a978cd9d2becf3cf8f4f2cb5ab0e1e74"
+  integrity sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==
+  dependencies:
+    acorn "^8.8.1"
 
 style-vendorizer@^2.0.0:
   version "2.2.3"
@@ -2571,6 +2863,21 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tinybench@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
+  integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
+
+tinypool@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.0.tgz#c405d8b743509fc28ea4ca358433190be654f819"
+  integrity sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==
+
+tinyspy@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.2.tgz#6da0b3918bfd56170fb3cd3a2b5ef832ee1dff0d"
+  integrity sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -2627,6 +2934,11 @@ twind@^0.16.17:
     htmlparser2 "^6.0.0"
     style-vendorizer "^2.0.0"
 
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -2639,6 +2951,11 @@ typescript@^4.4.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+ufo@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.0.1.tgz#64ed43b530706bda2e4892f911f568cf4cf67d29"
+  integrity sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==
 
 unload@2.2.0:
   version "2.2.0"
@@ -2668,6 +2985,18 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vite-node@0.26.2:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.26.2.tgz#2624236b9d68ea62c753572ee465fe4fa0657572"
+  integrity sha512-4M/zlatItZAyvrQG+82zQBhgDjRZRhVJYFW4T9wcAKh7eMmSiPOVSeI5zsV9UzHXgCcIDKX0o0r3s4OxExTHqg==
+  dependencies:
+    debug "^4.3.4"
+    mlly "^1.0.0"
+    pathe "^0.2.0"
+    source-map "^0.6.1"
+    source-map-support "^0.5.21"
+    vite "^3.0.0 || ^4.0.0"
+
 vite@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.2.tgz#2a7b4642c53ae066cf724e7e581d6c1fd24e2c32"
@@ -2679,6 +3008,39 @@ vite@^3.0.0:
     rollup "^2.75.6"
   optionalDependencies:
     fsevents "~2.3.2"
+
+"vite@^3.0.0 || ^4.0.0":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.0.3.tgz#de27ad3f263a03ae9419cdc8bc07721eadcba8b9"
+  integrity sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==
+  dependencies:
+    esbuild "^0.16.3"
+    postcss "^8.4.20"
+    resolve "^1.22.1"
+    rollup "^3.7.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vitest@^0.26.2:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.26.2.tgz#c1647e41d5619d1d059ff65d9c00672261ccac30"
+  integrity sha512-Jvqxh6SDy9SsuslkDjts0iDewDIdq4rveEt69YgDuAb1tVDGV0lDepVaeAFraoySWqneJmOt4TngFFNhlw7GfA==
+  dependencies:
+    "@types/chai" "^4.3.4"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    acorn "^8.8.1"
+    acorn-walk "^8.2.0"
+    chai "^4.3.7"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    source-map "^0.6.1"
+    strip-literal "^1.0.0"
+    tinybench "^2.3.1"
+    tinypool "^0.3.0"
+    tinyspy "^1.0.2"
+    vite "^3.0.0 || ^4.0.0"
+    vite-node "0.26.2"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
This PR adds `vitest` as well as a new `buildTree` utility function that can be used for ergonomic retrieval of all child `blob` nodes for a given repository path.

I've added a small test suite that exercises the core functionality of this utility function.